### PR TITLE
Update for 0.9.13 and add Docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ services:
         environment:
             GUACD_HOSTNAME: guacd
             GUACD_PORT: 4822
+            GUACAMOLE_HOME: /config
 ```
 The structure of guacamole-data looks like:
 ```

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ With this configuration for Docker, a database is not required (requires 0.9.13)
 
 **NOTE** Be sure to `chmod 755` the extension jar or it will not be loaded! Also, the very first request for authentication fails with a 500 error, but all subsequent requests succeed.
 
-
+### guacamole.properties
 This extension adds extra config keys to `guacamole.properties`:
 
 | Variable                | Required | Default | Comments                                                                                                                 |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # guacamole-auth-hmac
 
-Built for **Guacamole 0.9.12-incubating**.
+Built for **Guacamole 0.9.13-incubating**.
 
 ## Description
 
@@ -25,6 +25,53 @@ The resulting jar file will be placed in `target/guacamole-auth-hmac-<version>.j
 at least that version before using this plugin.
 
 Copy `guacamole-auth-hmac.jar` to the location specified by [`lib-directory`][config-classpath] in `guacamole.properties`.
+
+### Docker Configuration
+Mount a directory containing `guacamole-auth-hmac-0.9.13-incubating.jar` to the extensions directory one directory under the directory that is defined as GUACAMOLE_HOME. An example docker-compose.yml is provided below:
+
+```
+version: '3'
+services:
+  guacd:
+        image: guacamole/guacd:0.9.13-incubating
+        hostname: guacd
+        restart: always
+
+    guacamole:
+        image: guacamole/guacamole:0.9.13-incubating
+        hostname: guacamole
+        restart: always
+        links:
+            - guacd
+        ports:
+            - "8080:8080"
+        volumes:
+            - ./guacamole-data/config:/config
+        depends_on:
+            - guacd            
+        environment:
+            GUACD_HOSTNAME: guacd
+            GUACD_PORT: 4822
+```
+The structure of guacamole-data looks like:
+```
+guacamole-data
+└── config
+    ├── extensions
+    │   └── guacamole-auth-hmac-0.9.13-incubating.jar
+    ├── guacamole.properties
+    └── lib
+```
+And guacamole.properties contains:
+```
+secret-key: <some-secret-key>
+timestamp-age-limit: 100000
+auth-provider: com.stephensugden.guacamole.net.hmac.HmacAuthenticationProvider
+```
+With this configuration for Docker, a database is not required (requires 0.9.13).
+
+**NOTE** Be sure to `chmod 755` the extension jar or it will not be loaded! Also, the very first request for authentication fails with a 500 error, but all subsequent requests succeed.
+
 
 This extension adds extra config keys to `guacamole.properties`:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.stephensugden.guacamole</groupId>
     <artifactId>guacamole-auth-hmac</artifactId>
     <packaging>jar</packaging>
-    <version>0.9.12-incubating</version>
+    <version>0.9.13-incubating</version>
     <name>guacamole-auth-hmac</name>
 
     <properties>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-ext</artifactId>
-            <version>0.9.12-incubating</version>
+            <version>0.9.13-incubating</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/guac-manifest.json
+++ b/src/main/resources/guac-manifest.json
@@ -1,5 +1,5 @@
 {
-  "guacamoleVersion" : "0.9.12-incubating",
+  "guacamoleVersion" : "0.9.13-incubating",
 
   "name"      : "HMAC Authentication",
   "namespace" : "auth-hmac",


### PR DESCRIPTION
I've update the version strings to work with 0.9.13 and also added instructions on how to get the extension to work with guacamole in Docker container. 

If you have any idea why the first requests fails with a 500 internal server error, please let me know. The error trace is below:

```
guacamole_1      | 20:57:30.639 [http-nio-8080-exec-1] ERROR o.a.g.rest.RESTExceptionWrapper - An internal error occurred, but did not contain an error message. Enable debug-level logging for details.
guacamole_1      | 09-Oct-2017 20:57:30.644 SEVERE [http-nio-8080-exec-1] null.null Mapped exception to response: 500 (Internal Server Error)
guacamole_1      |  org.apache.guacamole.rest.APIException
guacamole_1      | 	at org.apache.guacamole.rest.RESTExceptionWrapper.invoke(RESTExceptionWrapper.java:202)
guacamole_1      | 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
guacamole_1      | 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
guacamole_1      | 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
guacamole_1      | 	at java.lang.reflect.Method.invoke(Method.java:498)
guacamole_1      | 	at com.sun.jersey.spi.container.JavaMethodInvokerFactory$1.invoke(JavaMethodInvokerFactory.java:60)
guacamole_1      | 	at com.sun.jersey.server.impl.model.method.dispatch.AbstractResourceMethodDispatchProvider$TypeOutInvoker._dispatch(AbstractResourceMethodDispatchProvider.java:185)
guacamole_1      | 	at com.sun.jersey.server.impl.model.method.dispatch.ResourceJavaMethodDispatcher.dispatch(ResourceJavaMethodDispatcher.java:75)
guacamole_1      | 	at com.sun.jersey.server.impl.uri.rules.HttpMethodRule.accept(HttpMethodRule.java:302)
guacamole_1      | 	at com.sun.jersey.server.impl.uri.rules.ResourceClassRule.accept(ResourceClassRule.java:108)
guacamole_1      | 	at com.sun.jersey.server.impl.uri.rules.RightHandPathRule.accept(RightHandPathRule.java:147)
guacamole_1      | 	at com.sun.jersey.server.impl.uri.rules.RootResourceClassesRule.accept(RootResourceClassesRule.java:84)
guacamole_1      | 	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1511)
guacamole_1      | 	at com.sun.jersey.server.impl.application.WebApplicationImpl._handleRequest(WebApplicationImpl.java:1442)
guacamole_1      | 	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1391)
guacamole_1      | 	at com.sun.jersey.server.impl.application.WebApplicationImpl.handleRequest(WebApplicationImpl.java:1381)
guacamole_1      | 	at com.sun.jersey.spi.container.servlet.WebComponent.service(WebComponent.java:416)
guacamole_1      | 	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:538)
guacamole_1      | 	at com.sun.jersey.spi.container.servlet.ServletContainer.service(ServletContainer.java:716)
guacamole_1      | 	at javax.servlet.http.HttpServlet.service(HttpServlet.java:725)
guacamole_1      | 	at com.google.inject.servlet.ServletDefinition.doService(ServletDefinition.java:263)
guacamole_1      | 	at com.google.inject.servlet.ServletDefinition.service(ServletDefinition.java:178)
guacamole_1      | 	at com.google.inject.servlet.ManagedServletPipeline.service(ManagedServletPipeline.java:91)
guacamole_1      | 	at com.google.inject.servlet.FilterChainInvocation.doFilter(FilterChainInvocation.java:62)
guacamole_1      | 	at com.google.inject.servlet.ManagedFilterPipeline.dispatch(ManagedFilterPipeline.java:118)
guacamole_1      | 	at com.google.inject.servlet.GuiceFilter.doFilter(GuiceFilter.java:113)
guacamole_1      | 	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:239)
guacamole_1      | 	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
guacamole_1      | 	at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:219)
guacamole_1      | 	at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:106)
guacamole_1      | 	at org.apache.catalina.authenticator.AuthenticatorBase.invoke(AuthenticatorBase.java:501)
guacamole_1      | 	at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:142)
guacamole_1      | 	at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:79)
guacamole_1      | 	at org.apache.catalina.valves.AbstractAccessLogValve.invoke(AbstractAccessLogValve.java:610)
guacamole_1      | 	at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:88)
guacamole_1      | 	at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:516)
guacamole_1      | 	at org.apache.coyote.http11.AbstractHttp11Processor.process(AbstractHttp11Processor.java:1086)
guacamole_1      | 	at org.apache.coyote.AbstractProtocol$AbstractConnectionHandler.process(AbstractProtocol.java:659)
guacamole_1      | 	at org.apache.coyote.http11.Http11NioProtocol$Http11ConnectionHandler.process(Http11NioProtocol.java:223)
guacamole_1      | 	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.doRun(NioEndpoint.java:1558)
guacamole_1      | 	at org.apache.tomcat.util.net.NioEndpoint$SocketProcessor.run(NioEndpoint.java:1515)
guacamole_1      | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
guacamole_1      | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
guacamole_1      | 	at org.apache.tomcat.util.threads.TaskThread$WrappingRunnable.run(TaskThread.java:61)
guacamole_1      | 	at java.lang.Thread.run(Thread.java:748)
```